### PR TITLE
Support __cast_map__ dictionary containing field names and callables...

### DIFF
--- a/datacaster/exceptions.py
+++ b/datacaster/exceptions.py
@@ -16,3 +16,6 @@ class UnsupportedCast(ValueError):
 
 class CastFailed(ValueError):
     pass
+
+class MultipleCastDefinitions(Exception):
+    pass

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ TEST_DEPENDENCIES = [
 setup(
     name="datacaster",
     description="Cast class attributes on instantiation.",
-    version="0.4.1",
+    version="0.5.0",
     author="Tom Guyatt",
     maintainer="Tom Guyatt",
     author_email="tomguyatt@gmail.com",


### PR DESCRIPTION
… used to cast them. Useful for when you want to define a caster function once and use it for multiple fields