### PR TITLE
Support renaming fields on instantiation

### DIFF
--- a/datacaster/classes.py
+++ b/datacaster/classes.py
@@ -128,6 +128,14 @@ class CastDataClass:
         TYPE_FUNCTIONS = _get_config_item(lambda: self.__class_config__["cast_functions"]["types"], {})
         ALWAYS_CAST = _get_config_item(lambda: self.__class_config__["always_cast"], [])
 
+        # If any fields are to be renamed, do it now before kwargs are inspected.
+        if RENAMED_FIELDS := _get_config_item(lambda: self.__class_config__["rename_fields"], []):
+            for original_name, new_name in RENAMED_FIELDS.items():
+                # Create a new kwargs item with the new name & original value.
+                kwargs[new_name] = kwargs[original_name]
+                # Chuck the old kwargs item away.
+                _ = kwargs.pop(original_name, None)
+
         # Type check the default values of any attributes that will be using
         # default values. We want to do this as soon as possible.
         defaulted_attributes = self._get_defaulted_attributes(kwargs)

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ TEST_DEPENDENCIES = [
 setup(
     name="datacaster",
     description="Cast class attributes on instantiation.",
-    version="0.7.1",
+    version="0.8.0",
     author="Tom Guyatt",
     maintainer="Tom Guyatt",
     author_email="tomguyatt@gmail.com",

--- a/tests/unit/test_classes.py
+++ b/tests/unit/test_classes.py
@@ -281,6 +281,7 @@ def test_repr():
 
 
 def test_eq():
+
     class TypeMap(CastDataClass):
         __class_config__ = {
             "cast_functions": {
@@ -291,10 +292,10 @@ def test_eq():
 
     constructor = {"string": 123, "integer": "123", "floating": "1.0", "list_string": ["1", "2", "3"], "tuple_int": "1"}
     assert SimpleDataClass(**constructor) == SimpleDataClass(**constructor)
-    assert not SimpleDataClass(**constructor) == SimpleDataClass(
+    assert SimpleDataClass(**constructor) != SimpleDataClass(
         **{key: value for key, value in constructor.items() if key != "string"}
     )
-    assert not SimpleDataClass(**constructor) == TypeMap(list_of_strings=[1, 2, 3])
+    assert SimpleDataClass(**constructor) != TypeMap(list_of_strings=[1, 2, 3])
 
 
 def test_class_config_defaults():
@@ -314,3 +315,18 @@ def test_cast_always():
         name: str
 
     assert AlwaysCastString(name="lol").__dict__ == {"name": "lol lol!"}
+
+
+def test_rename_fields():
+    class Renamed(CastDataClass):
+        new_name_1: str
+        new_name_2: int
+
+        __class_config__ = {
+            "rename_fields": {
+                "OriginalNameOne": "new_name_1",
+                "OriginalNameTwo": "new_name_2",
+            }
+        }
+
+    assert Renamed(OriginalNameOne="test value", OriginalNameTwo="1").__dict__ == {"new_name_1": "test value", "new_name_2": 1}


### PR DESCRIPTION
You may want to create a Python object with field names that differ to what a third party API provided.

This PR supports a new class config dictionary that maps incoming field names to the new field names.

A new key & value is created in kwargs using the new name & original value. The original key is then thrown away.