### PR TITLE
Bump Typeguard to 2.13.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: python
 python:
   - "3.8"
+  - "3.10"
 
 # command to install package
 install:

--- a/setup.py
+++ b/setup.py
@@ -4,13 +4,13 @@ TEST_DEPENDENCIES = [
     "pytest==4.6.3",
     "pytest-cov==2.8.1",
     "coverage==5.0",
-    "typeguard==2.7.1",
+    "typeguard==2.13.3",
 ]
 
 setup(
     name="datacaster",
     description="Cast class attributes on instantiation.",
-    version="0.9.1",
+    version="0.9.2",
     author="Tom Guyatt",
     maintainer="Tom Guyatt",
     author_email="tomguyatt@gmail.com",
@@ -24,7 +24,7 @@ setup(
         "Programming Language :: Python",
         "Topic :: Software Development :: Libraries :: Python Modules",
     ],
-    install_requires=["typeguard==2.7.1"],
+    install_requires=["typeguard==2.13.3"],
     tests_require=TEST_DEPENDENCIES,
     extras_require={"test": TEST_DEPENDENCIES},
     test_suite="tests",


### PR DESCRIPTION
When using datacaster with python 3.10, we are seeing an AttributeError exception being raised as typeguard is trying to use `__args__` which was removed in python 3.9. This bumps typeguard to the latest version which doesn't use `__args__` directly. 